### PR TITLE
edited jarsigner command at :apksignerkey

### DIFF
--- a/Script.bat
+++ b/Script.bat
@@ -827,7 +827,7 @@ set KEYSTORE_PASS=apksigner
 set KEYSTORE_ALIAS=apksigner.keystore
 set JAVAC_PATH=%JAVA_HOME%\bin\
 set PATH=%PATH%;%JAVAC_PATH%;
-call jarsigner -keystore %KEYSTORE_FILE% -storepass %KEYSTORE_PASS% -keypass %KEYSTORE_PASS% -signedjar %~dp0place-apk-here-for-signing/signed%capp% %~dp0place-apk-here-for-signing/unsigned%capp%  %KEYSTORE_ALIAS% %1
+call jarsigner -sigalg MD5withRSA -digestalg SHA1 -keystore %KEYSTORE_FILE% -storepass %KEYSTORE_PASS% -keypass %KEYSTORE_PASS% -signedjar %~dp0place-apk-here-for-signing/signed%capp% %~dp0place-apk-here-for-signing/unsigned%capp% %KEYSTORE_ALIAS%
 IF errorlevel 1 (
 ECHO "An Error Occured, Please Check The Log (option 26)"
 PAUSE


### PR DESCRIPTION
in jre 1.7, you need to add -sigalg and -digestalg to the jarsigner command. if not, the APK will still sign, and google play will accept it but *it won't install on users devices*!

i also removed the %1 at the end of the command, i can't see what parameter you're using.